### PR TITLE
updates ANN construction [cxx]

### DIFF
--- a/ann/cxx/plots.py
+++ b/ann/cxx/plots.py
@@ -28,7 +28,7 @@ from numpy import arange
 from numpy import loadtxt
 from matplotlib import pyplot as plt
 
-y, y_pred = loadtxt('results.txt').transpose()
+y, y_pred = loadtxt('train-results.txt').transpose()
 t = arange(y.size)
 
 plt.close('all')
@@ -38,4 +38,17 @@ ax.scatter(t, y, color = 'black', label = 'actual')
 ax.scatter(t, y_pred, color = 'red', label = 'predicted')
 ax.set_xlabel('time (days)')
 ax.set_ylabel('non-dimensional temperature')
+ax.set_title('train set')
+ax.legend()
+
+
+y, y_pred = loadtxt('test-results.txt').transpose()
+t = arange(y.size)
+
+fig, ax = plt.subplots()
+ax.scatter(t, y, color = 'black', label = 'actual')
+ax.scatter(t, y_pred, color = 'red', label = 'predicted')
+ax.set_xlabel('time (days)')
+ax.set_ylabel('non-dimensional temperature')
+ax.set_title('test set')
 ax.legend()


### PR DESCRIPTION
    COMMENTS:
    The ANN construction now closely follows reference [2], where the
    bias is a scalar quantity not a vector (you are encouraged to
    look at the source code of the author).
    
    The bias vector lead to overfitting. The ANN would closely
    describe the train set but fail to do so for the test set.
    The issue is that the size of the bias vector is determined by the
    number of measurements. Since the train and test sets differ in
    size it is clear that the optimized bias vector is incompatible
    for the test set from a linear algebra viewpoint.
    
    Now the ANN is just able to capture the qualitative behavior of
    the sets; however, this is to be expected for such a simple ANN that
    consists of just the input layer. It would be interesting to see how
    a robust ANN would perform.