### PR TITLE
drops deprecated regression options [Python]

### DIFF
--- a/training-and-testing/linear-multivariate-regression.py
+++ b/training-and-testing/linear-multivariate-regression.py
@@ -70,16 +70,14 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size = 0.2,
                                                     random_state = 0)
 
 # obtains a linear model
-model = LinearRegression (fit_intercept = True, normalize = True,
-                          copy_X = True, n_jobs = None)
+model = LinearRegression (fit_intercept = True, copy_X = True, n_jobs = None)
 model.fit(X_train, y_train)
 score = model.score(X_test, y_test)
 print(f'linear model score: {score}')
 
-
 # obtains a regularized linear model
 model = LassoCV(eps = 2**-16, n_alphas = 256, alphas = None, fit_intercept = True,
-                normalize = True, precompute = 'auto', max_iter = 1024, tol = 2**-16,
+                precompute = 'auto', max_iter = 1024, tol = 2**-16,
                 copy_X = True, cv = 5, verbose = False, n_jobs = None,
                 positive = False, random_state = None, selection = 'cyclic')
 

--- a/training-and-testing/polynomial-multivariate-regression.py
+++ b/training-and-testing/polynomial-multivariate-regression.py
@@ -78,8 +78,7 @@ polX_test = pf.fit_transform(stdX_test)
 
 ''' gets polynomial model '''
 
-model = LinearRegression (fit_intercept = True, normalize = False,
-                          copy_X = True, n_jobs = None)
+model = LinearRegression (fit_intercept = True, copy_X = True, n_jobs = None)
 
 model.fit(polX_train, y_train)
 score = model.score(polX_test, y_test)
@@ -88,7 +87,7 @@ print(f'polynomial model score: {score}')
 ''' gets regularized polynomial model '''
 
 model = LassoCV(eps = 2**-16, n_alphas = 256, alphas = None, fit_intercept = True,
-                normalize = False, precompute = 'auto', max_iter = 1024, tol = 2**-16,
+                precompute = 'auto', max_iter = 1024, tol = 2**-16,
                 copy_X = True, cv = 5, verbose = False, n_jobs = None,
                 positive = False, random_state = None, selection = 'cyclic')
 


### PR DESCRIPTION
COMMENTS:
Most recent (installed) version of sklearn has deprecated the normalize option from regression models; this change has been done in response to the update of the sklearn module in my PC.